### PR TITLE
setTrialPeriod function correction

### DIFF
--- a/src/Services/SubscriptionPeriod.php
+++ b/src/Services/SubscriptionPeriod.php
@@ -23,13 +23,17 @@ class SubscriptionPeriod
 
     protected $plan;
     protected $startDate;
+    protected $actualPlan;
 
     public function __construct(Plan|PlanCombination $plan, Carbon $startDate)
     {
         $this->plan = $plan;
         $this->startDate = $startDate;
 
-        if ($this->plan->trial_period > 0) {
+        // Determine the actual plan to check for trial period
+        $this->actualPlan = ($plan instanceof PlanCombination) ? $plan->plan : $plan;
+
+        if ($this->actualPlan->trial_period > 0) {
             $this->setTrialPeriod();
         } else {
             $this->setSubscriptionPeriod();
@@ -71,7 +75,7 @@ class SubscriptionPeriod
      */
     private function setTrialPeriod()
     {
-        $trial = new Period($this->plan->trial_interval, $this->plan->trial_period, $this->startDate);
+        $trial = new Period($this->actualPlan->trial_interval, $this->actualPlan->trial_period, $this->startDate);
         $this->trialEnd = $trial->getEndDate();
     }
 

--- a/src/Traits/HasTrialPeriodUsage.php
+++ b/src/Traits/HasTrialPeriodUsage.php
@@ -41,7 +41,14 @@ trait HasTrialPeriodUsage
      */
     public function getTrialPeriodRemainingUsageIn(string $interval): int
     {
-        return Carbon::now()->{CarbonHelper::diffIn($interval)}($this->trial_ends_at);
+        // Check if the current date is after the trial end date
+        if (Carbon::now()->greaterThanOrEqualTo($this->trial_ends_at)) {
+            // The trial period has ended, return 0
+            return 0;
+        } else {
+            // Otherwise, return the remaining duration of the trial period
+            return Carbon::now()->{CarbonHelper::diffIn($interval)}($this->trial_ends_at);
+        }
     }
 
     /**


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Migrations
YES | NO

## Description
I have corrected this in instances where we are using PlanCombination instead of a Plan to fetch the actual plan to use its trial date and trial interval. Since those are not found in PlanCombination trial end date was set as null in case a PlanCombination was being passed upon calling the newSubscription function.

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
No migration needed.


## Impacted Areas in Application
List general components of the application that this PR will affect:

class SubscriptionPeriod

trait HasTrialPeriodUsage > getTrialPeriodRemainingUsageIn
* 
